### PR TITLE
Feature/allow logging time to user stories

### DIFF
--- a/src/api/tp.js
+++ b/src/api/tp.js
@@ -56,7 +56,7 @@ var TargetProcess = (function() {
     return request(ajax_opts);
   };
 
-  TargetProcess.prototype.getTaskOrBug = function (id, done) {
+  TargetProcess.prototype.getStoryOrTaskOrBug = function (id, done) {
     function failure(err) {
         done((err && err.response && err.response.Message) ||
         'An error occured while fetching task from target process.');
@@ -67,18 +67,28 @@ var TargetProcess = (function() {
     }
 
     var me = this;
-    me.getTask(id).then(success, function (err) {
-        if(err.statusCode === 404) {
-            me.getBug(id).then(success, function (err) {
-                if(err.statusCode === 404) {
-                    done('Task/Bug with Id '+id+' could not be found or access is forbidden.');
-                }
-                else failure(err);
-            });
-        }
-        else failure(err);
+    me.getStory(id).then(success, function (err) {
+      if (err.statusCode === 404) {
+        me.getTask(id).then(success, function (err) {
+            if(err.statusCode === 404) {
+                me.getBug(id).then(success, function (err) {
+                    if(err.statusCode === 404) {
+                        done('Story/Task/Bug with Id '+id+' could not be found or access is forbidden.');
+                    }
+                    else failure(err);
+                });
+            }
+            else failure(err);
+        });
+      } else failure(err);
     });
   };
+
+  TargetProcess.prototype.getStory = function(id, ajax_opts) {
+    var url = this.full_url + '/Userstories/' + id;
+    ajax_opts = this.build_ajax_options(url, ajax_opts);
+    return request(ajax_opts);
+  }
 
   TargetProcess.prototype.getTask = function(id, ajax_opts) {
     var url = this.full_url + '/Tasks/' + id;

--- a/src/api/tp.js
+++ b/src/api/tp.js
@@ -17,6 +17,7 @@ var TargetProcess = (function() {
     };
 
     this.bugTimeBehavior = opts['bug-time'];
+    this.allowLoggingTimeToUserStories = opts['story-time'] === 'true';
   }
 
   TargetProcess.prototype.build_ajax_options = function(uri, opts) {
@@ -67,7 +68,12 @@ var TargetProcess = (function() {
     }
 
     var me = this;
-    me.getStory(id).then(success, function (err) {
+    me.getStory(id).then(function(result) {
+      if (!me.allowLoggingTimeToUserStories) {
+        done('Your config means that time cannot be logged directly onto user stories');
+      }
+      success(result);
+    }, function (err) {
       if (err.statusCode === 404) {
         me.getTask(id).then(success, function (err) {
             if(err.statusCode === 404) {

--- a/src/api/tp.js
+++ b/src/api/tp.js
@@ -68,26 +68,24 @@ var TargetProcess = (function() {
     }
 
     var me = this;
-    me.getStory(id).then(function(result) {
-      if (!me.allowLoggingTimeToUserStories) {
-        done('Your config means that time cannot be logged directly onto user stories');
-      }
-      success(result);
-    }, function (err) {
-      if (err.statusCode === 404) {
         me.getTask(id).then(success, function (err) {
             if(err.statusCode === 404) {
                 me.getBug(id).then(success, function (err) {
                     if(err.statusCode === 404) {
+                      me.getStory(id).then(function(result) {
+                        if (!me.allowLoggingTimeToUserStories) {
+                          done('Your config means that time cannot be logged directly onto user stories');
+                        }
+                        success(result);
+                      }, function (err) {
                         done('Story/Task/Bug with Id '+id+' could not be found or access is forbidden.');
+                      });
                     }
                     else failure(err);
                 });
             }
             else failure(err);
         });
-      } else failure(err);
-    });
   };
 
   TargetProcess.prototype.getStory = function(id, ajax_opts) {

--- a/src/commands/time/_base.js
+++ b/src/commands/time/_base.js
@@ -22,9 +22,8 @@ function captureNewTime(args, tpClient, done) {
 
             var tpEntity;
             function prepare(id, done) {
-                tpClient.getTaskOrBug(id, function (err, e) {
+                tpClient.getStoryOrTaskOrBug(id, function (err, e) {
                     if(err) return done(err);
-
                     tpEntity = e;
 
                     // set project from mappings
@@ -42,9 +41,14 @@ function captureNewTime(args, tpClient, done) {
                 if(!tpEntity) return '';
 
                 var task = { id: tpEntity.Id, name: tpEntity.Name, type: tpEntity.ResourceType.toLowerCase() };
-                var us  = tpEntity.UserStory ?
+                var us;
+                if (tpEntity.ResourceType === 'UserStory') {
+                    us = { id: tpEntity.Id, name: tpEntity.Name };
+                } else {
+                    us = tpEntity.UserStory ?
                           { id: tpEntity.UserStory.Id, name: tpEntity.UserStory.Name } :
                           null;
+                }
                 return createTpNote(task, us);
             }
 
@@ -54,7 +58,7 @@ function captureNewTime(args, tpClient, done) {
                     var done = this.async();
                     prepare(i, done);
                 }),
-                message: 'Any target process task/bug? (id without #)',
+                message: 'Any target process story/task/bug? (id without #)',
                 filter: build
             };
 

--- a/src/commands/time/_base.js
+++ b/src/commands/time/_base.js
@@ -41,13 +41,11 @@ function captureNewTime(args, tpClient, done) {
                 if(!tpEntity) return '';
 
                 var task = { id: tpEntity.Id, name: tpEntity.Name, type: tpEntity.ResourceType.toLowerCase() };
-                var us;
+                var us = null;
                 if (tpEntity.ResourceType === 'UserStory') {
                     us = { id: tpEntity.Id, name: tpEntity.Name };
-                } else {
-                    us = tpEntity.UserStory ?
-                          { id: tpEntity.UserStory.Id, name: tpEntity.UserStory.Name } :
-                          null;
+                } else if (tpEntity.UserStory) {
+                    us = { id: tpEntity.UserStory.Id, name: tpEntity.UserStory.Name };
                 }
                 return createTpNote(task, us);
             }

--- a/src/config.js
+++ b/src/config.js
@@ -30,7 +30,8 @@ var properties = {
     'domain',
     'email',
     { key: 'password', protected: true },
-    { key: 'bug-time', default: 'both', values: ['none', 'bug', 'user-story', 'both'] }
+    { key: 'bug-time', default: 'both', values: ['none', 'bug', 'user-story', 'both'] },
+    { key: 'story-time', default: 'false', values: ['true', 'false'] }
   ]
 };
 


### PR DESCRIPTION
Allows users to log time directly onto TP User Stories (without needing a task).
This requires the tp config 'story-time' to be set to 'true' (default is false).